### PR TITLE
Handle gid=None

### DIFF
--- a/src/adapters/csvfile.py
+++ b/src/adapters/csvfile.py
@@ -62,7 +62,7 @@ class CSVFileHelper(AbstractAdapter):
         if isinstance(data.get('date'), date):
             data['date'] = data.get('date').strftime("%Y-%m-%d")
 
-        data['gid'] = ":".join(data.get('gid', []))
+        data['gid'] = ":".join(data.get('gid', [])) if data.get('gid') is not None else ''
         return data
 
     def get_adm_division(self, countrycode: str, adm_area_1: str = None, adm_area_2: str = None,

--- a/src/utils/helpers.py
+++ b/src/utils/helpers.py
@@ -1,8 +1,10 @@
 import os
 import pandas as pd
+import logging
 from pandas import DataFrame
 from typing import Tuple, List
 
+logger = logging.getLogger(__name__)
 
 class AdmTranslator:
     def __init__(self, csv_fname: str):
@@ -34,7 +36,8 @@ class AdmTranslator:
                     continue
 
                 if row.gid is None:
-                    raise Exception(f'Unable to get GID for: {row.adm_area_1} {row.adm_area_2} {row.adm_area_3}')
+                    logger.warning(f'Unable to get GID for: {row.adm_area_1} {row.adm_area_2} {row.adm_area_3}')
+                    return True, row.adm_area_1, row.adm_area_2, row.adm_area_3, None
 
                 return True, row.adm_area_1, row.adm_area_2, row.adm_area_3, row.gid.split(':')
         if return_original_if_failure:


### PR DESCRIPTION
In helpers.py it is now permissible to leave the gid column blank but complete the translation.
The csv method wasn't working because data.get('gid', []) only returns [] if 'gid' is a missing keyword, but often 'gid' is preset, just equal to None. I am not sure if a similar change is necessary for other adapters.