### PR TITLE
GBR - add warning

### DIFF
--- a/src/plugins/GBR_PHTW/fetcher.py
+++ b/src/plugins/GBR_PHTW/fetcher.py
@@ -66,6 +66,7 @@ class UnitedKingdomPHTWFetcher(AbstractFetcher):
             self.db.upsert_epidemiology_data(**upsert_obj)
 
         logger.debug('Fetching regional information')
+        logger.warning('Scotland and Wales report by health board - GIDs are approximations by local authorities')
         data = self.fetch_area()
 
         for index, record in data.iterrows():


### PR DESCRIPTION
Added warning to GBR_PHTW to clarify that GIDs are not accurate for Scotland or Wales. Should work on this later.