### PR TITLE
Report missing GIDS only once per region

### DIFF
--- a/src/plugins/WRD_WHO/fetcher.py
+++ b/src/plugins/WRD_WHO/fetcher.py
@@ -37,6 +37,7 @@ class WorldWHOFetcher(BaseEpidemiologyFetcher):
 
     def run(self):
         data = self.fetch()
+        missing_country_codes = set()
 
         for index, record in data.iterrows():
 
@@ -50,7 +51,7 @@ class WorldWHOFetcher(BaseEpidemiologyFetcher):
                 country_a2_code=country_a2_code)
 
             if pd.isna(countrycode):
-                logger.warning(f'Unable to process: {record}')
+                missing_country_codes.add(country_origin)
                 continue
 
             upsert_obj = {
@@ -67,3 +68,6 @@ class WorldWHOFetcher(BaseEpidemiologyFetcher):
             }
 
             self.upsert_data(**upsert_obj)
+
+        for country in missing_country_codes:
+            logger.warning(f'Unable to find country code for {country}')

--- a/src/utils/plugins.py
+++ b/src/utils/plugins.py
@@ -142,6 +142,7 @@ class Plugins:
                 data_adapter.truncate_staging()
             plugin_instance = plugin(data_adapter)
             plugin_instance.run()
+            data_adapter.publish_missing_gids()
             data_adapter.flush()
             validation_success = self.validate_consistency(plugin,
                                                            plugin_instance,


### PR DESCRIPTION
Abstract adapter now stores missing GIDS for release when the plugin finishes running - will make log file shorter, easier to use. Similar functionality in WRD_WHO fetcher.