### PR TITLE
Bypass certificate verification for CAN_GOV

### DIFF
--- a/src/plugins/CAN_GOV/fetcher.py
+++ b/src/plugins/CAN_GOV/fetcher.py
@@ -16,6 +16,8 @@ import logging
 import pandas as pd
 import math
 from datetime import datetime
+import io
+import requests
 
 __all__ = ('CanadaFetcher',)
 
@@ -31,7 +33,9 @@ class CanadaFetcher(BaseEpidemiologyFetcher):
     def fetch(self):
         # a csv file to be downloaded
         url = 'https://health-infobase.canada.ca/src/data/covidLive/covid19.csv'
-        return pd.read_csv(url)
+        s = requests.get(url, verify=False).content
+        df = pd.read_csv(io.StringIO(s.decode('utf-8')))
+        return df
 
     def run(self):
         data = self.fetch()


### PR DESCRIPTION
Downloading csv file creates the error
urllib.error.URLError: <urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1076)>
The file opens in Safari so this is a Python error.
This change simply bypasses verification of the certificate - a more intelligent resolution may be available.